### PR TITLE
Apply modern dark theme

### DIFF
--- a/src/app/components/menu-categories/menu-categories.component.css
+++ b/src/app/components/menu-categories/menu-categories.component.css
@@ -2,4 +2,14 @@
     ion-list{
         padding-top: 0!important;
     }
+
+    ion-item{
+        --background: transparent;
+        transition: background-color 0.3s;
+    }
+
+    ion-item:hover{
+        --background: var(--ion-color-primary);
+        color: var(--ion-color-primary-contrast);
+    }
 }

--- a/src/app/components/order-page/order-page.component.css
+++ b/src/app/components/order-page/order-page.component.css
@@ -10,6 +10,8 @@
         justify-content: space-between;
         align-items: center;
         align-content: center;
+        padding: 1rem;
+        background: var(--ion-item-background, #2d2d3c);
 
         ion-card-title{
             font-size: 1rem;

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,9 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#1976d2">
 </head>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,11 @@
-/* You can add global styles to this file, and also import other style files */
+/* Global styles */
+body {
+  font-family: 'Inter', sans-serif;
+  background: linear-gradient(135deg, #1e1e2f, #27293d);
+  color: var(--ion-text-color, #ffffff);
+}
+
+ion-card {
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -8,3 +8,19 @@
 /* @import "@ionic/angular/css/palettes/dark.always.css"; */
 /* @import "@ionic/angular/css/palettes/dark.class.css"; */
 @import "@ionic/angular/css/palettes/dark.system.css";
+
+:root {
+  --ion-font-family: 'Inter', sans-serif;
+
+  --ion-color-primary: #ff6f61;
+  --ion-color-primary-rgb: 255, 111, 97;
+  --ion-color-primary-contrast: #ffffff;
+  --ion-color-primary-contrast-rgb: 255, 255, 255;
+  --ion-color-primary-shade: #e65e52;
+  --ion-color-primary-tint: #ff8275;
+
+  --ion-background-color: #1e1e2f;
+  --ion-background-color-rgb: 30, 30, 47;
+  --ion-text-color: #ffffff;
+  --ion-text-color-rgb: 255, 255, 255;
+}


### PR DESCRIPTION
## Summary
- add Google font and modern gradient styles
- tweak card look and menu item hover
- define new dark palette variables

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bfe16f36c8323a1501f38a4d9357e