### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/app/components/order-page/order-page.component.css
+++ b/src/app/components/order-page/order-page.component.css
@@ -1,6 +1,10 @@
 :host{
     ion-avatar{
         margin: auto;
+        img{
+            width: 100%;
+            height: auto;
+        }
     }
     ion-card{
         height: 100%;

--- a/src/app/components/order-page/order-page.component.html
+++ b/src/app/components/order-page/order-page.component.html
@@ -1,4 +1,4 @@
-<ion-split-pane when="xs" contentId="main">
+<ion-split-pane when="md" contentId="main">
   <ion-menu class="ion-no-padding" contentId="main">
     <ion-content>
       <app-menu-categories


### PR DESCRIPTION
## Summary
- adjust split-pane to only activate on medium screens to improve mobile layout
- ensure avatar images scale responsively

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0200dbe4832382ab94df05e1758b